### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/pex/logging/BlockTimingLog.h
+++ b/include/lsst/pex/logging/BlockTimingLog.h
@@ -36,6 +36,9 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
+#include <memory>
+#include <string>
+
 namespace lsst {
 namespace pex {
 namespace logging {

--- a/include/lsst/pex/logging/BlockTimingLog.h
+++ b/include/lsst/pex/logging/BlockTimingLog.h
@@ -336,7 +336,7 @@ private:
     int _tracelev;
     int _pusageFlags, _usageFlags;
     std::string _funcName;
-    boost::scoped_ptr<struct rusage> _usage;
+    std::unique_ptr<struct rusage> _usage;
 };
 
 }}}     // end lsst::pex::logging

--- a/include/lsst/pex/logging/BlockTimingLog.h
+++ b/include/lsst/pex/logging/BlockTimingLog.h
@@ -35,7 +35,6 @@
 
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <boost/scoped_ptr.hpp>
 
 namespace lsst {
 namespace pex {

--- a/include/lsst/pex/logging/FileDestination.h
+++ b/include/lsst/pex/logging/FileDestination.h
@@ -62,7 +62,7 @@ public:
      *                       new messages will be appended to the file.
      */
     FileDestination(const std::string& filepath,
-                    const boost::shared_ptr<LogFormatter>& formatter, 
+                    const std::shared_ptr<LogFormatter>& formatter, 
                     int threshold=threshold::PASS_ALL,
                     bool truncate=false) 
         : LogDestination(new std::ofstream(filepath.c_str(),
@@ -72,7 +72,7 @@ public:
           _path(filepath) 
     { }
     FileDestination(const char *filepath,
-                    const boost::shared_ptr<LogFormatter>& formatter, 
+                    const std::shared_ptr<LogFormatter>& formatter, 
                     int threshold=threshold::PASS_ALL,
                     bool truncate=false)
         : LogDestination(new std::ofstream(filepath,
@@ -82,7 +82,7 @@ public:
           _path(filepath) 
     { }
     FileDestination(const boost::filesystem::path& filepath,
-                    const boost::shared_ptr<LogFormatter>& formatter, 
+                    const std::shared_ptr<LogFormatter>& formatter, 
                     int threshold=threshold::PASS_ALL,
                     bool truncate=false)
         : LogDestination(new std::ofstream(filepath.string().c_str(),

--- a/include/lsst/pex/logging/Log.h
+++ b/include/lsst/pex/logging/Log.h
@@ -38,7 +38,7 @@
 #include <vector>
 #include <list>
 #include <cstdarg>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // If the compiler does not support attributes, disable them
 #ifndef __GNUC__
@@ -226,7 +226,7 @@ public:
      *                         The default is false, indicating that their 
      *                         display must be turned on as needed.  
      */
-    Log(const std::list<boost::shared_ptr<LogDestination> >& destinations, 
+    Log(const std::list<std::shared_ptr<LogDestination> >& destinations, 
         const lsst::daf::base::PropertySet& preamble,
         const std::string& name="", const int threshold=INFO,
         bool defaultShowAll=false);
@@ -570,7 +570,7 @@ public:
      * @param formatter     the log formatter to use.
      */
     void addDestination(std::ostream &destination, int threshold, 
-                        const boost::shared_ptr<LogFormatter> &formatter);
+                        const std::shared_ptr<LogFormatter> &formatter);
 
     /**
      * add a destination to this log.  The destination stream will included
@@ -578,7 +578,7 @@ public:
      * All previously created logs, including ancestor logs, will be 
      * unaffected.  
      */
-    void addDestination(const boost::shared_ptr<LogDestination> &destination) {
+    void addDestination(const std::shared_ptr<LogDestination> &destination) {
         _destinations.push_back(destination);
     }
 
@@ -621,7 +621,7 @@ public:
      *                         will override this one.)
      */
     static void createDefaultLog(
-        const std::list<boost::shared_ptr<LogDestination> >& destinations, 
+        const std::list<std::shared_ptr<LogDestination> >& destinations, 
         const lsst::daf::base::PropertySet& preamble,
         const std::string& name="", const int threshold=INFO);
 
@@ -676,20 +676,20 @@ private:
     void completePreamble();
 
     int _threshold;
-    boost::shared_ptr<bool> _defShowAll;
-    boost::shared_ptr<bool> _myShowAll;
+    std::shared_ptr<bool> _defShowAll;
+    std::shared_ptr<bool> _myShowAll;
     std::string _name;
 
 protected: 
     /**
      * the memory of child importance thresholds.
      */
-    boost::shared_ptr<threshold::Memory> _thresholds;
+    std::shared_ptr<threshold::Memory> _thresholds;
 
     /**
      * the list of destinations to send messages to
      */
-    std::list<boost::shared_ptr<LogDestination> > _destinations;
+    std::list<std::shared_ptr<LogDestination> > _destinations;
 
     /**
      * the list preamble data properties that are included with every 

--- a/include/lsst/pex/logging/LogDestination.h
+++ b/include/lsst/pex/logging/LogDestination.h
@@ -35,7 +35,7 @@
 
 #include <string>
 #include <ostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace lsst {
 namespace pex {
@@ -75,7 +75,7 @@ public:
      *                       to 0.  
      */
     LogDestination(std::ostream *strm, 
-                   const boost::shared_ptr<LogFormatter>& formatter, 
+                   const std::shared_ptr<LogFormatter>& formatter, 
                    int threshold=threshold::PASS_ALL);
 
     /**
@@ -120,7 +120,7 @@ public:
 protected:
     int _threshold;   // the stream's threshold
     std::ostream *_strm;   // the output stream
-    boost::shared_ptr<LogFormatter> _frmtr;    // the formatter to use
+    std::shared_ptr<LogFormatter> _frmtr;    // the formatter to use
 };
 
 }}}     // end lsst::pex::logging

--- a/include/lsst/pex/logging/LogRecord.h
+++ b/include/lsst/pex/logging/LogRecord.h
@@ -32,7 +32,7 @@
 
 #include "lsst/daf/base/PropertySet.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/format.hpp>
 #include <string>
 #include <sys/time.h>

--- a/include/lsst/pex/logging/PropertyPrinter.h
+++ b/include/lsst/pex/logging/PropertyPrinter.h
@@ -185,7 +185,7 @@ std::ostream& TmplPrinterIter<T>::write(std::ostream *strm) const {
  */
 class WrappedPrinterIter : public PrinterIter {
 public:
-    WrappedPrinterIter(boost::shared_ptr<PrinterIter> iter) : _it(iter) { }
+    WrappedPrinterIter(std::shared_ptr<PrinterIter> iter) : _it(iter) { }
     virtual ~WrappedPrinterIter();
     virtual std::ostream& write(std::ostream *strm) const;
     virtual PrinterIter& operator++();
@@ -195,7 +195,7 @@ public:
     virtual bool notAtEnd() const;
     virtual bool notLTBegin() const;
 private:
-    boost::shared_ptr<PrinterIter> _it;
+    std::shared_ptr<PrinterIter> _it;
 };
 
 /**
@@ -283,14 +283,14 @@ typename PrinterList::iterator TmplPrinterList<T>::begin() const {
     PrinterIter *it = new delegateIter(BaseTmplPrinterList<T>::_list.begin(), 
                                        BaseTmplPrinterList<T>::_list.begin(), 
                                        BaseTmplPrinterList<T>::_list.end());
-    return PrinterList::iterator(boost::shared_ptr<PrinterIter>(it));
+    return PrinterList::iterator(std::shared_ptr<PrinterIter>(it));
 }
 template <class T>
 typename PrinterList::iterator TmplPrinterList<T>::last() const { 
     PrinterIter *it = new delegateIter(BaseTmplPrinterList<T>::_list.end()-1, 
                                        BaseTmplPrinterList<T>::_list.begin(), 
                                        BaseTmplPrinterList<T>::_list.end());
-    return PrinterList::iterator(boost::shared_ptr<PrinterIter>(it));
+    return PrinterList::iterator(std::shared_ptr<PrinterIter>(it));
 }
 
 /**
@@ -486,7 +486,7 @@ public:
 
 
 private:
-    boost::shared_ptr<PrinterList> _list;
+    std::shared_ptr<PrinterList> _list;
 };
 
 }}}     // end lsst::pex::logging

--- a/include/lsst/pex/logging/threshold/Memory.h
+++ b/include/lsst/pex/logging/threshold/Memory.h
@@ -33,7 +33,7 @@
 #include <string>
 #include <map>
 #include <ostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/tokenizer.hpp>
 
 #include "lsst/pex/logging/threshold/enum.h"

--- a/python/lsst/pex/logging/loggingLib.i
+++ b/python/lsst/pex/logging/loggingLib.i
@@ -84,8 +84,8 @@ Access to the logging classes from the pex library
 namespace boost { namespace filesystem {}}
 %}
 
-%ignore lsst::pex::logging::FileDestination::FileDestination(const boost::filesystem::path& filepath, const boost::shared_ptr<lsst::pex::logging::LogFormatter>& formatter, int threshold, bool truncate);
-%ignore lsst::pex::logging::FileDestination::FileDestination(const char *filepath, const boost::shared_ptr<lsst::pex::logging::LogFormatter>& formatter, int threshold, bool truncate);
+%ignore lsst::pex::logging::FileDestination::FileDestination(const boost::filesystem::path& filepath, const std::shared_ptr<lsst::pex::logging::LogFormatter>& formatter, int threshold, bool truncate);
+%ignore lsst::pex::logging::FileDestination::FileDestination(const char *filepath, const std::shared_ptr<lsst::pex::logging::LogFormatter>& formatter, int threshold, bool truncate);
 %ignore lsst::pex::logging::FileDestination::FileDestination(const boost::filesystem::path& filepath, bool verbose, int threshold, bool truncate);
 %ignore lsst::pex::logging::FileDestination::FileDestination(const char *filepath, bool verbose, int threshold, bool truncate);
 
@@ -123,7 +123,7 @@ LoggingAddType(std::string, String)
     void addDestination(const std::string& filepath, bool verbose=false, 
                         int threshold=lsst::pex::logging::threshold::PASS_ALL) 
     {
-        boost::shared_ptr<lsst::pex::logging::LogDestination> 
+        std::shared_ptr<lsst::pex::logging::LogDestination> 
             fdest(new lsst::pex::logging::FileDestination(filepath, verbose, 
                                                           threshold));
         $self->addDestination(fdest);

--- a/src/DualLog.cc
+++ b/src/DualLog.cc
@@ -27,7 +27,7 @@
 #include "lsst/pex/logging/DualLog.h"
 
 #include <iostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace lsst {
 namespace pex {
@@ -36,7 +36,7 @@ namespace logging {
 //@cond
 
 using namespace std;
-using boost::shared_ptr;
+using std::shared_ptr;
 using lsst::daf::base::PropertySet;
 
 ///////////////////////////////////////////////////////////

--- a/src/FileDestination.cc
+++ b/src/FileDestination.cc
@@ -45,7 +45,7 @@ FileDestination::FileDestination(const boost::filesystem::path& filepath,
                                  bool verbose, int threshold, bool truncate)
     : LogDestination(new std::ofstream(filepath.string().c_str(), 
                                        truncate ? std::ios::out : std::ios::app), 
-                     boost::shared_ptr<LogFormatter>(new PrependedFormatter(verbose)),
+                     std::shared_ptr<LogFormatter>(new PrependedFormatter(verbose)),
                      threshold),
       _path(filepath) 
 { }
@@ -53,7 +53,7 @@ FileDestination::FileDestination(const std::string& filepath, bool verbose,
                                  int threshold, bool truncate)
     : LogDestination(new std::ofstream(filepath.c_str(), 
                                        truncate ? std::ios::out : std::ios::app), 
-                     boost::shared_ptr<LogFormatter>(new PrependedFormatter(verbose)),
+                     std::shared_ptr<LogFormatter>(new PrependedFormatter(verbose)),
                      threshold),
       _path(filepath) 
 { }
@@ -61,7 +61,7 @@ FileDestination::FileDestination(const char *filepath, bool verbose,
                                  int threshold, bool truncate)
     : LogDestination(new std::ofstream(filepath, 
                                        truncate ? std::ios::out : std::ios::app), 
-                     boost::shared_ptr<LogFormatter>(new PrependedFormatter(verbose)),
+                     std::shared_ptr<LogFormatter>(new PrependedFormatter(verbose)),
                      threshold),
       _path(filepath) 
 { }

--- a/src/Log.cc
+++ b/src/Log.cc
@@ -31,7 +31,7 @@
 #include "lsst/pex/logging/Log.h"
 #include "lsst/pex/logging/ScreenLog.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace lsst {
 namespace pex {
@@ -42,7 +42,7 @@ namespace logging {
 using std::string;
 using std::list;
 using std::ostream;
-using boost::shared_ptr;
+using std::shared_ptr;
 using lsst::daf::base::PropertySet;
 
 ///////////////////////////////////////////////////////////

--- a/src/LogDestination.cc
+++ b/src/LogDestination.cc
@@ -27,7 +27,7 @@
 #include "lsst/pex/logging/LogDestination.h"
 #include "lsst/pex/logging/LogRecord.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/any.hpp>
 
 using namespace std;
@@ -37,7 +37,7 @@ namespace pex {
 namespace logging {
 
 //@cond
-using boost::shared_ptr;
+using std::shared_ptr;
 
 /*
  * @brief create a destination with a threshold.  

--- a/src/LogFormatter.cc
+++ b/src/LogFormatter.cc
@@ -34,7 +34,7 @@
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/PropertySet.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/any.hpp>
 #include <string>
 #include <sstream>

--- a/src/LogRecord.cc
+++ b/src/LogRecord.cc
@@ -28,7 +28,7 @@
 #include "lsst/pex/exceptions.h"
 #include "lsst/daf/base/DateTime.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <stdexcept>
 #include <time.h>
 
@@ -78,7 +78,7 @@ LogRecord::LogRecord(int threshold, int importance, const PropertySet& preamble,
         _data = preamble.deepCopy();
     }
     else {
-        _data = boost::shared_ptr<PropertySet>(new PropertySet());
+        _data = std::shared_ptr<PropertySet>(new PropertySet());
     }
     _init();
 }

--- a/src/PropertyPrinter.cc
+++ b/src/PropertyPrinter.cc
@@ -76,12 +76,12 @@ DateTimePrinterList::~DateTimePrinterList() { }
 DateTimePrinterList::iterator DateTimePrinterList::begin() const { 
     PrinterIter *it = new DateTimePrinterIter(_list.begin(), 
                                               _list.begin(), _list.end());
-    return iterator(boost::shared_ptr<PrinterIter>(it));
+    return iterator(std::shared_ptr<PrinterIter>(it));
 }
 DateTimePrinterList::iterator DateTimePrinterList::last() const { 
     PrinterIter *it = new DateTimePrinterIter(_list.end()-1, 
                                               _list.begin(), _list.end());
-    return iterator(boost::shared_ptr<PrinterIter>(it));
+    return iterator(std::shared_ptr<PrinterIter>(it));
 }
 
 PrinterList* makeDateTimePrinter(const PropertySet& prop, 
@@ -102,12 +102,12 @@ BoolPrinterList::~BoolPrinterList() { }
 BoolPrinterList::iterator BoolPrinterList::begin() const { 
     PrinterIter *it = new BoolPrinterIter(_list.begin(), 
                                           _list.begin(), _list.end());
-    return iterator(boost::shared_ptr<PrinterIter>(it));
+    return iterator(std::shared_ptr<PrinterIter>(it));
 }
 BoolPrinterList::iterator BoolPrinterList::last() const { 
     PrinterIter *it = new BoolPrinterIter(_list.end()-1, 
                                           _list.begin(), _list.end());
-    return iterator(boost::shared_ptr<PrinterIter>(it));
+    return iterator(std::shared_ptr<PrinterIter>(it));
 }
 
 PrinterList* makeBoolPrinter(const PropertySet& prop, 
@@ -143,7 +143,7 @@ PropertyPrinter::PropertyPrinter(const PropertySet& prop,
     if (_list.get() == 0) {
         PropertySet tmp;
         tmp.set(name, "<unprintable>");
-        _list = boost::shared_ptr<PrinterList>(fact.makePrinter(tmp, name));
+        _list = std::shared_ptr<PrinterList>(fact.makePrinter(tmp, name));
     }
 }
  

--- a/src/ScreenLog.cc
+++ b/src/ScreenLog.cc
@@ -27,7 +27,7 @@
 #include "lsst/pex/logging/ScreenLog.h"
 
 #include <iostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 using namespace std;
 
@@ -36,7 +36,7 @@ namespace pex {
 namespace logging {
 
 //@cond
-using boost::shared_ptr;
+using std::shared_ptr;
 using lsst::daf::base::PropertySet;
 
 ///////////////////////////////////////////////////////////

--- a/tests/testDefLog.cc
+++ b/tests/testDefLog.cc
@@ -24,7 +24,7 @@
 #include "lsst/pex/logging/ScreenLog.h"
 #include <iostream>
 #include <exception>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 using lsst::pex::logging::Log;
 using lsst::daf::base::Citizen;

--- a/tests/testFileDest.cc
+++ b/tests/testFileDest.cc
@@ -23,7 +23,7 @@
 #include "lsst/pex/logging/Log.h"
 #include "lsst/pex/logging/FileDestination.h"
 #include <iostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 using lsst::pex::logging::Log;
 using lsst::pex::logging::FileDestination;
@@ -44,9 +44,9 @@ int main() {
     lsst::pex::logging::LogDestination *ld = new lsst::pex::logging::FileDestination(filepath, threshold);
     delete ld;
 
-    boost::shared_ptr<LogFormatter> brief(new PrependedFormatter());
+    std::shared_ptr<LogFormatter> brief(new PrependedFormatter());
 
-    boost::shared_ptr<LogDestination> 
+    std::shared_ptr<LogDestination> 
         shy(new FileDestination("tests/testFileDestination-out.txt", true));
     Log log;
     log.addDestination(shy);

--- a/tests/testLog.cc
+++ b/tests/testLog.cc
@@ -23,7 +23,7 @@
 #include "lsst/pex/logging.h"
 #include "lsst/pex/logging/ScreenLog.h"
 #include <iostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 using lsst::pex::logging::Log;
 using lsst::pex::logging::ScreenLog;
@@ -34,7 +34,7 @@ using lsst::pex::logging::Prop;
 using lsst::pex::logging::RecordProperty;
 using lsst::daf::base::Citizen;
 using lsst::daf::base::PropertySet;
-using boost::shared_ptr;
+using std::shared_ptr;
 using namespace std;
 
 void assure(bool mustBeTrue, const string& failureMsg) {

--- a/tests/testLogDestination.cc
+++ b/tests/testLogDestination.cc
@@ -23,7 +23,7 @@
 #include "lsst/pex/logging/LogDestination.h"
 #include "lsst/pex/logging/LogRecord.h"
 #include <iostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 using lsst::pex::logging::LogRecord;
 using lsst::pex::logging::LogFormatter;
@@ -50,7 +50,7 @@ int main() {
     lr1.addComment("This is a test");
     lr2.addComment("This is a test");
 
-    boost::shared_ptr<LogFormatter> brief(new BriefFormatter());
+    std::shared_ptr<LogFormatter> brief(new BriefFormatter());
 
     LogDestination shy(&cerr, brief, 10);
     cerr << "Shy: " << endl;


### PR DESCRIPTION
Makes the following replacements:
- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
